### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/app.js
+++ b/app.js
@@ -141,10 +141,21 @@ app.post(
 
 app.get('/uploads/:filename', (req, res) => {
     const filename = req.params.filename;
-    const filePath = path.join(__dirname, 'uploads', filename);
+    const uploadsDir = path.resolve(__dirname, 'uploads');
+    const requestedPath = path.resolve(uploadsDir, filename);
+    let finalPath;
+    try {
+        finalPath = fs.realpathSync(requestedPath);
+    } catch (e) {
+        return res.status(404).json({ message: 'Image not found' });
+    }
 
-    if (fs.existsSync(filePath)) {
-        res.sendFile(filePath);
+    if (!finalPath.startsWith(uploadsDir + path.sep)) {
+        return res.status(403).json({ message: 'Access denied' });
+    }
+
+    if (fs.existsSync(finalPath)) {
+        res.sendFile(finalPath);
     } else {
         res.status(404).json({ message: 'Image not found' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/13](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/13)

To fix this issue, we need to ensure that any file access in `/uploads/:filename` is restricted to files genuinely located inside the `uploads` directory and that malicious path traversal is not possible. The established method is as follows:
- After constructing the path to the file based on user input, use `path.resolve` to resolve it relative to the uploads directory.
- Use `fs.realpathSync` (with try/catch) to resolve symbolic links and obtain the canonical file system path.
- Check that the final path starts with the intended `uploads` root. If it does not, block the request.

Only the code within the `/uploads/:filename` route handler (lines 142–151) needs to be fixed. No extra user-facing behavior is introduced; legitimate filenames within the `uploads` folder will resolve and serve, while malicious or unsupported filenames will yield a 404 or 403.

**Additional needs:**
- No new methods or packages are required; use the existing `fs`, `path`.
- No changes needed outside this route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
