### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/app.js
+++ b/app.js
@@ -141,7 +141,14 @@ app.post(
 
 app.get('/uploads/:filename', (req, res) => {
     const filename = req.params.filename;
-    const filePath = path.join(__dirname, 'uploads', filename);
+    const uploadsDir = path.join(__dirname, 'uploads');
+    // Construct the absolute path for the requested file
+    const filePath = path.resolve(uploadsDir, filename);
+
+    // Ensure that filePath is within uploadsDir
+    if (!filePath.startsWith(uploadsDir + path.sep)) {
+        return res.status(403).json({ message: 'Forbidden' });
+    }
 
     if (fs.existsSync(filePath)) {
         res.sendFile(filePath);


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/12](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/12)

To fix the uncontrolled path traversal vulnerability, the file path derived from user input should be robustly validated and restricted to prevent accessing files outside of the intended `uploads` directory. The best approach is to resolve the requested path relative to the uploads directory (`path.resolve`), check that it is still inside the intended directory after resolution, and refuse access otherwise. Additionally, using only the base name of the filename would prevent directory traversal, but the full validation using `path.resolve` and a root check is more robust if subdirectories may be allowed in future. 

Required changes:
- In the `/uploads/:filename` route, replace construction of `filePath` so that it resolves against the uploads directory.
- After resolving the path, check that the resulting absolute path starts with the expected uploads directory path.
- Only serve the file if the check passes; otherwise, respond with a 403 Forbidden status.

This solution only requires updates to the shown code in app.js, imports for `path` and `fs` are already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
