### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,14 @@ const prisma = new PrismaClient();
 const port = 3000;
 const multer = require('multer');
 const schedule = require('node-schedule');
+const rateLimit = require('express-rate-limit');
 
+// Set up rate limiter: maximum of 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    message: { message: "Too many requests from this IP, please try again later." }
+});
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
         cb(null, 'uploads/');
@@ -288,6 +295,7 @@ app.get(
 );
 
 app.delete(
+    limiter,
     '/delete-habito/:id',
     authLib.validateAuthorization,
     async (req, res) => {
@@ -327,6 +335,7 @@ app.delete(
 );
 
 app.put(
+    limiter,
     '/update-habito-completado/:id',
     authLib.validateAuthorization,
     async (req, res) => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/11](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/11)

To address the missing rate limiting, we should add a rate-limiting middleware using a well-known package (`express-rate-limit`) to the sensitive routes (`/delete-habito/:id` and `/update-habito-completado/:id`). To implement this:
- Install and import `express-rate-limit`.
- Create a rate limiter instance (e.g., max N requests per window per IP).
- Add the rate limiter to the targeted sensitive routes by placing it in their middleware chain, immediately before the handler function.
- Ensure only minimal changes: add the import, limiter definition, and insert `limiter` into the list of middlewares for those routes.

All changes are to be made in `app.js` only, and only in the regions you've shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
