### PR TITLE
Potential fix for code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,14 @@ const prisma = new PrismaClient();
 const port = 3000;
 const multer = require('multer');
 const schedule = require('node-schedule');
+const rateLimit = require('express-rate-limit');
 
+// Limit to 100 requests per 15 minutes
+const habitsLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP/user to 100 requests per windowMs
+    message: { message: 'Too many requests, please try again later.' }
+});
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
         cb(null, 'uploads/');
@@ -252,6 +259,7 @@ app.post(
 );
 
 app.get(
+    habitsLimiter,
     '/get-habitos',
     authLib.validateAuthorization,
     async (req, res) => {
@@ -288,6 +296,7 @@ app.get(
 );
 
 app.delete(
+    habitsLimiter,
     '/delete-habito/:id',
     authLib.validateAuthorization,
     async (req, res) => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/10](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/10)

To fix this problem, introduce rate limiting middleware to the affected routes using the popular `express-rate-limit` package.  
**General fix:**  
- Install and import `express-rate-limit`.  
- Set up a rate limiter (e.g., allow up to 100 requests per 15 minutes per IP/user).
- Apply the limiter specifically to the `/get-habitos` and `/delete-habito/:id` routes by adding it to their middleware array (as done for `authLib.validateAuthorization`).  
- Changes are needed in the top region of `app.js` to require and configure the limiter, and to add the limiter to the route definitions for these two endpoints.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
