### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const prisma = new PrismaClient();
 const port = 3000;
 const multer = require('multer');
 const schedule = require('node-schedule');
+const rateLimit = require('express-rate-limit');
 
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
@@ -253,6 +254,7 @@ app.post(
 
 app.get(
     '/get-habitos',
+    habitsLimiter,
     authLib.validateAuthorization,
     async (req, res) => {
         try {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/9](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/9)

To fix this problem, we should add a rate limiting middleware to the `/get-habitos` route. The most straightforward method is to use the well-maintained `express-rate-limit` library. The rate limiter should be appropriately configured (e.g., 100 requests per 15 minutes per IP or per user). Since both `/crear-habito` and `/get-habitos` hit the database, it makes sense to apply rate limiting to both for consistency, but the CodeQL finding is specifically about `/get-habitos`.

**Steps:**  
1. Import `express-rate-limit` near the top of the file.
2. Define a rate limiter (e.g., allowing 100 requests per 15 minutes).
3. Apply the limiter middleware to the `/get-habitos` route (place it before the route handler).
4. Optionally, rate limit can be applied to other sensitive routes, but for this fix, target only `/get-habitos`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
