### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,14 @@ const prisma = new PrismaClient();
 const port = 3000;
 const multer = require('multer');
 const schedule = require('node-schedule');
+const rateLimit = require('express-rate-limit');
 
+// Rate limiter for habit creation endpoint
+const crearHabitoLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+    message: { message: "Too many habit creations from this IP, please try again later." }
+});
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
         cb(null, 'uploads/');
@@ -206,6 +213,7 @@ app.post(
 app.use('/uploads', express.static('uploads'));
 
 app.post(
+    crearHabitoLimiter,
     '/crear-habito',
     authLib.validateAuthorization,
     validateRequestBody(['nombre', 'frequencia', 'categoria']),

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/8](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/8)

To fix the missing rate limiting issue, apply a rate limiter middleware to the `/crear-habito` route so that clients cannot make excessive requests to this database-interacting endpoint. The `express-rate-limit` npm package is the preferred, well-known solution for Express apps. You should:

- Import `express-rate-limit` at the top of the file.
- Create a rate limiter instance, e.g., allow 100 requests per 15 minutes per IP (adjust as appropriate).
- Add the limiter middleware specifically to the `/crear-habito` chain (so as not to affect other routes).
- Insert the limiter middleware *before* the handler function: after authentication/validation is OK, but it's more common to put the limiter first; both orders work.
This change should be implemented in `app.js`, adding the import at the top and inserting the limiter in the chain for the `/crear-habito` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
