### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const prisma = new PrismaClient();
 const port = 3000;
 const multer = require('multer');
 const schedule = require('node-schedule');
+const rateLimit = require('express-rate-limit');
 
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
@@ -187,8 +188,16 @@ app.post(
     }
 );
 
+// Limit to 10 profile picture uploads per 15 minutes per IP
+const profilePicUploadLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 10,
+    message: { message: 'Too many profile picture uploads from this IP, please try again after 15 minutes.' }
+});
+
 app.post(
     '/upload-profile-picture',
+    profilePicUploadLimiter,
     authLib.validateAuthorization,
     upload.single('profile_picture'),
     async (req, res) => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/7](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/7)

The best fix is to add a rate-limiting middleware to the `/upload-profile-picture` route to restrict the number of requests each client can make in a given time window. The widely used `express-rate-limit` package provides this functionality and is very easy to integrate.

**Steps:**
- Import the `express-rate-limit` package at the top of the file.
- Create a rate limiter instance for file uploads (for example, limit to 10 requests per 15 minutes per IP).
- Apply this limiter as middleware specifically to the `/upload-profile-picture` route in the route declaration.

**Required changes:**
- Add `express-rate-limit` import (top of the file).
- Create a new limiter instance (near other global config).
- Add the limiter as middleware to the relevant route (`/upload-profile-picture`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
