### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const prisma = new PrismaClient();
 const port = 3000;
 const multer = require('multer');
 const schedule = require('node-schedule');
+const rateLimit = require('express-rate-limit');
 
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
@@ -150,8 +151,18 @@ app.get('/uploads/:filename', (req, res) => {
     }
 });
 
+// Rate limiter for uploads: max 10 requests per 15 minutes per IP
+const uploadImageLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10, // limit each IP to 10 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false,
+    message: { message: 'Too many upload attempts from this IP, please try again later.' }
+});
+
 app.post(
     '/upload-image',
+    uploadImageLimiter,
     validateRequestBody(['image']),
     authLib.validateAuthorization,
     async (req, res) => {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/6](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/6)

To address the lack of rate limiting on the `/upload-image` route, we should add a rate-limiting middleware to this endpoint. The best-practice, and simplest approach, is to use an established library such as `express-rate-limit`. This solution prevents abuse and DoS by capping how many times a client can hit the endpoint over a time window.

- **How to fix in general:** Apply a rate-limiting middleware to the endpoint to limit the number of upload attempts per IP over a period.
- **Best way in this code:** Import `express-rate-limit` at the top of the file (after other requires), define a rate limiter with reasonable defaults (e.g., max 10 uploads per 15 minutes per IP), then add this limiter as middleware to the route in question (`/upload-image`).
- **File/lines to change:**  
  - `app.js`:  
    - Add an import for `express-rate-limit` after existing requires.
    - Define a limiter instance (before the route declaration).
    - Add the limiter as middleware argument for the `/upload-image` route (on line 155, before or after validation/auth middlewares).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
