### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/5](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/5)

To fix the problem, we need to introduce a rate-limiting middleware to the `/upload-image` POST route. The recommended approach is to use the well-known `express-rate-limit` package, which is simple, effective, and widely used. We should import it (`require('express-rate-limit')`), define a limiter instance with suitable parameters (window duration and max requests per window, e.g., 100 requests per 15 minutes for a default starting point), and add the limiter as a middleware component to the `/upload-image` endpoint. We should not apply the limiter globally, but only to this resource-intensive route to minimize impact on other routes.

Edits involve:

- Importing `express-rate-limit`
- Defining a `rateLimiter` config instance at the top of the file
- Inserting the rate limiter middleware into the `/upload-image` route -- specifically, as one of the middlewares in the list in the `app.post("/upload-image", ...)` definition.

All edits will be limited to the app.js file, visible in the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
