### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "node-schedule": "^2.1.1"
+        "node-schedule": "^2.1.1",
+        "express-rate-limit": "^8.2.1"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/4](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/4)

To fix this issue, introduce a rate limiting middleware and apply it to the `/uploads/:filename` route (and possibly more endpoints, though only this one is required). The `express-rate-limit` package is well-known, simple, and sufficient for this purpose. Add the import (require statement) for the package, define a suitable limiter (for example, 100 requests per 15 minutes per IP, which can be tuned as appropriate), and apply it as middleware to the problematic route. Only the regions in `app.js` shown above need to be changed: add the require at the top, define the limiter after creating the Express app, and add the limiter as middleware on `/uploads/:filename`. No existing functionality or business logic need change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
