### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,7 +52,8 @@ app.post(
         try {
             console.log('Login request received');
             const { email, password } = req.body;
-            console.log(email, password);
+            // Do not log plain-text passwords!
+            console.log(`Login attempted for email: ${email}`);
             const token = await authLib.loginUser(email, password);
 
             if (!token) {


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/2](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/2)

To fix the problem, the logging statement on line 55 should be changed so that it does *not* log the password value. Instead, if needed for debugging, the statement can log only the email or a custom message indicating a login attempt was made—never the raw password. The fix involves editing `app.js` to remove `password` from the `console.log` on line 55. No new libraries or dependencies are required; this is a straightforward code edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
