### PR TITLE
Potential fix for code scanning alert no. 19: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,7 +152,16 @@ app.post(
     }
 );
 
-app.get('/uploads/:filename', (req, res) => {
+// Rate limiter for downloads: max 100 requests per 15 minutes per IP
+const downloadImageLimiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { message: 'Too many download attempts from this IP, please try again later.' }
+});
+
+app.get('/uploads/:filename', downloadImageLimiter, (req, res) => {
     const filename = req.params.filename;
     const uploadsDir = path.join(__dirname, 'uploads');
     // Construct the absolute path for the requested file


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/19](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/19)

To fix the problem, a rate-limiting middleware should be applied to the `/uploads/:filename` route. This can be accomplished using the popular `express-rate-limit` package, which is already imported as `RateLimit` (line 7). For consistency with the `/upload-image` route, we should create a specific rate limiter for file downloads (e.g., maximum 100 requests per 15 minutes per IP) and apply it as middleware to this endpoint.

- In `app.js`, define a new limiter just before the route using the `RateLimit` function.
- Apply this limiter as middleware in the `/uploads/:filename` route (i.e., as an additional parameter to the route definition).
- No changes to the core file serving logic are required—just add rate limiting middleware.
- Ensure any necessary imports/definitions are present (but in this case, `RateLimit` is already imported).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
