### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,10 @@ const { PrismaClient } = require('@prisma/client');
 const path = require('path');
 const fs = require('fs');
 const RateLimit = require('express-rate-limit'); // Added for rate limiting
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
 const app = express();
 const prisma = new PrismaClient();
 const port = 3000;
@@ -330,6 +334,7 @@ app.get(
 app.delete(
     '/delete-habito/:id',
     authLib.validateAuthorization,
+    limiter,
     async (req, res) => {
         try {
             const habitId = parseInt(req.params.id, 10); // Get habit ID from the route params
@@ -369,6 +374,7 @@ app.delete(
 app.put(
     '/update-habito-completado/:id',
     authLib.validateAuthorization,
+    limiter,
     async (req, res) => {
         try {
             const habitId = parseInt(req.params.id, 10);


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/11](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/11)

To fix the problem, we should apply a rate-limiting middleware to the sensitive routes flagged by CodeQL (`DELETE /delete-habito/:id` and `PUT /update-habito-completado/:id`). The best way to do this without affecting existing functionality is to:

- Define a rate limiter with sensible default settings specific to these routes (e.g., allow up to 100 requests per 15 minutes per IP).
- Apply the limiter as middleware directly to the specific route definitions, by inserting the limiter between the authorization middleware and the route logic (i.e., as the second argument in the route handler chain).
- Ensure that the import for `express-rate-limit` is present (already present on line 7), and define the limiter instance.
- Make these changes within the shown code in app.js, and do not assume any wider/global rate limiting beyond the snippet.

You will need to:

- Add the limiter definition to the file.
- Add the limiter middleware to both affected route handlers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
