### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -297,6 +297,7 @@ app.post(
 
 app.get(
     '/get-habitos',
+    limiter,
     authLib.validateAuthorization,
     async (req, res) => {
         try {


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/9](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/9)

To fix this error, the `limiter` middleware (already defined as using `express-rate-limit`) should be applied to each route that performs sensitive database operations, including the `'/get-habitos'` route. This can be done by passing the limiter middleware as one of the arguments to the route handler (such as between the path and the handler functions). Specifically, add `limiter` as a middleware argument to `app.get('/get-habitos', ...)`. No changes are needed to the definition of `limiter` itself. Ensure to do the same for other sensitive endpoints in the future.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
