### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -251,6 +251,7 @@ app.use('/uploads', express.static('uploads'));
 
 app.post(
     '/crear-habito',
+    limiter,
     authLib.validateAuthorization,
     validateRequestBody(['nombre', 'frequencia', 'categoria']),
     async (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/8](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/8)

**General fix approach:**  
To mitigate this vulnerability, the rate-limiting middleware should be explicitly applied to the `/crear-habito` POST endpoint. This can be done by adding the `limiter` middleware in the middleware stack for this route.

**Detailed fix:**  
Insert the `limiter` middleware in the list of middlewares for the `/crear-habito` route. In code terms, update the route at line 252–253 as follows:
```js
app.post(
    '/crear-habito',
    limiter, // <--- add this here
    authLib.validateAuthorization,
    ...
)
```
This will ensure that requests to this endpoint are rate-limited as per the existing configuration (100 requests per 15 minutes per IP).

**File/Region to change:**  
- File: `app.js`
- Region: The route definition for `/crear-habito` (lines 252–296).

**Methods/imports/definitions needed:**  
No additional imports or definitions are needed; `limiter` is already defined and imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
