### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -342,8 +342,8 @@ app.get(
 
 app.delete(
     '/delete-habito/:id',
-    authLib.validateAuthorization,
     limiter,
+    authLib.validateAuthorization,
     async (req, res) => {
         try {
             const habitId = parseInt(req.params.id, 10); // Get habit ID from the route params


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/20](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/20)

**How to fix:**  
To address this issue, the rate-limiting middleware (`limiter`) should be applied *before* any potentially expensive or sensitive operations, including authorization checks. This ensures that rate limiting is enforced at the earliest opportunity, protecting expensive operations from abuse.

**Detailed fix:**  
In the `/delete-habito/:id` route definition (lines 343–381), the list of middleware currently puts `authLib.validateAuthorization` before `limiter`:

```js
app.delete(
  '/delete-habito/:id',
  authLib.validateAuthorization,
  limiter,
  async (req, res) => { ... }
);
```
This must be changed so that `limiter` comes first:

```js
app.delete(
  '/delete-habito/:id',
  limiter,
  authLib.validateAuthorization,
  async (req, res) => { ... }
);
```
No other new methods, imports, or dependencies are required (everything is already present).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
