### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/app.js
+++ b/app.js
@@ -382,8 +382,8 @@ app.delete(
 
 app.put(
     '/update-habito-completado/:id',
-    authLib.validateAuthorization,
     limiter,
+    authLib.validateAuthorization,
     async (req, res) => {
         try {
             const habitId = parseInt(req.params.id, 10);


### PR DESCRIPTION
Potential fix for [https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/20](https://github.com/lucasditomase/Grupo-3-Servidor/security/code-scanning/20)

**General approach:**  
To fix the problem, reorder middleware in the Express route declaration so that the rate limiter (`limiter`) is the very first middleware executed on that endpoint, before any other custom logic (including `authLib.validateAuthorization`). This ensures incoming requests are rate-limited before invoking potentially expensive authorization, business logic, or database operations.

**Details:**  
- In `app.put('/update-habito-completado/:id', ...)`, change the order of the middleware so that `limiter` is placed *before* `authLib.validateAuthorization`.
- No new methods, imports, or definitions are needed since the rate limiter is already set up; only the ordering needs correction.
- Only the relevant region of `app.js` (lines 384–416, i.e. the `/update-habito-completado/:id` route definition) should be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
